### PR TITLE
Fix hub creation with internal user id

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -82,22 +82,46 @@
   let hubId = null;
 
   async function getOrCreateHub() {
-    const { data: hub } = await supabase
-      .from('hubs')
-      .select('*')
-      .eq('owner_id', user.id)
+    // Get the authenticated user ID from the session
+    const { data: sessionData } = await supabase.auth.getSession();
+    const authId = sessionData?.session?.user?.id;
+
+    if (!authId) {
+      console.error('No active session found');
+      return;
+    }
+
+    // Look up the internal user row using the auth ID
+    const { data: userRow, error: userError } = await supabase
+      .from('users')
+      .select('id')
+      .eq('auth_id', authId)
       .single();
 
-    if (hub) {
-      hubId = hub.id;
+    if (userError || !userRow) {
+      console.error('Failed to find user row:', userError?.message || 'Not found');
+      return;
+    }
+
+    const internalUserId = userRow.id;
+
+    // Check if a hub already exists for this user
+    const { data: existingHub } = await supabase
+      .from('hubs')
+      .select('*')
+      .eq('owner_id', internalUserId)
+      .single();
+
+    if (existingHub) {
+      hubId = existingHub.id;
     } else {
-      const { data: newHub, error: hubError } = await supabase
+      const { data: newHub, error: hubCreateError } = await supabase
         .from('hubs')
-        .insert([{ owner_id: user.id, name: 'My Hub' }])
+        .insert([{ owner_id: internalUserId, name: 'My Hub' }])
         .select()
         .single();
 
-      if (hubError) {
+      if (hubCreateError) {
         alert('Failed to create hub');
         return;
       }
@@ -122,7 +146,10 @@
     data.forEach(asset => {
       const el = document.createElement('div');
       el.className = 'asset';
-      el.innerHTML = `<strong>${asset.name}</strong><br>${asset.description}`;
+      el.innerHTML = `
+        <a href="asset_page.html?id=${asset.id}"><strong>${asset.name}</strong></a><br>
+        ${asset.description}
+      `;
       container.appendChild(el);
     });
   }


### PR DESCRIPTION
## Summary
- use auth_id lookup to fetch internal user id before creating or fetching hub
- link assets to the asset page for easier navigation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bd184706c83338e32f3b5eaca06db