### PR TITLE
Fix storage bucket reference

### DIFF
--- a/asset_page.html
+++ b/asset_page.html
@@ -119,7 +119,7 @@
       if (!file) return;
 
       const { data, error } = await supabase.storage
-        .from('promptly-files')
+        .from('asset-files')
         .upload(`${assetId}/${file.name}`, file);
 
       if (error) {
@@ -131,7 +131,7 @@
 
     async function loadFiles() {
       const { data, error } = await supabase.storage
-        .from('promptly-files')
+        .from('asset-files')
         .list(`${assetId}/`);
 
       const fileList = document.getElementById('fileList');
@@ -139,7 +139,7 @@
       if (data) {
         for (const file of data) {
           const link = await supabase.storage
-            .from('promptly-files')
+            .from('asset-files')
             .createSignedUrl(`${assetId}/${file.name}`, 3600);
 
           fileList.innerHTML += `<div class="file-entry">


### PR DESCRIPTION
## Summary
- correct bucket name in asset_page.html from `promptly-files` to `asset-files`

## Testing
- `grep -R "asset-files" -n Promptly-App | head`

------
https://chatgpt.com/codex/tasks/task_e_685bf778b37c8333bd5406abd2a2a1c6