### PR TITLE
Add service status page and link

### DIFF
--- a/api/services.json
+++ b/api/services.json
@@ -1,0 +1,6 @@
+[
+  {"name": "Authentication Service", "status": "operational"},
+  {"name": "Database", "status": "operational"},
+  {"name": "Email Service", "status": "degraded"},
+  {"name": "File Storage", "status": "maintenance"}
+]

--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
         >
           Get Started
         </a>
+        <div class="mt-4">
+          <a href="services_status.html" class="text-blue-600 hover:underline">View Service Status</a>
+        </div>
       </div>
     </section>
 

--- a/services_status.html
+++ b/services_status.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Service Status - Promptly</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-800 font-sans">
+  <div class="max-w-4xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-6 text-center">Service Status</h1>
+    <table class="min-w-full bg-white rounded shadow">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="px-4 py-2 text-left">Service</th>
+          <th class="px-4 py-2 text-left">Status</th>
+        </tr>
+      </thead>
+      <tbody id="services-body"></tbody>
+    </table>
+    <div class="mt-6 text-center">
+      <a href="index.html" class="text-blue-600 underline">Back to Home</a>
+    </div>
+  </div>
+
+  <script>
+    fetch('api/services.json')
+      .then(response => response.json())
+      .then(services => {
+        const tbody = document.getElementById('services-body');
+        services.forEach(service => {
+          const row = document.createElement('tr');
+          row.innerHTML = `<td class="border-t px-4 py-2">${service.name}</td>` +
+                          `<td class="border-t px-4 py-2">${service.status}</td>`;
+          tbody.appendChild(row);
+        });
+      })
+      .catch(() => {
+        const tbody = document.getElementById('services-body');
+        const row = document.createElement('tr');
+        row.innerHTML = '<td class="px-4 py-2" colspan="2">Failed to load service data.</td>';
+        tbody.appendChild(row);
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mock API services endpoint
- show service statuses in a new page
- link to the service status page from the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c1770d6ec8333988e5ec2fc21b343