### PR TITLE
Add README and environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and set your Supabase credentials
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Promptly App
+
+Promptly is a React application for managing field assets. It allows teams to sign up, create hubs, add assets, upload files, attach notes and manage user roles. Assets can be accessed via QR codes and users can monitor service status of supporting infrastructure.
+
+## Prerequisites
+
+- **Node.js** (version 18 or later recommended)
+- **Vite** – installed as a dev dependency. No global installation is required.
+
+## Installation
+
+Clone the repository and install dependencies:
+
+```bash
+npm install
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` in the project root and configure your Supabase credentials. At minimum define:
+
+```bash
+VITE_SUPABASE_URL=your-supabase-url
+VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
+These values will be loaded by Vite at build time.
+
+## Development
+
+Start the development server with hot reloading:
+
+```bash
+npm run dev
+```
+
+Open the provided local URL in your browser to view the app.
+
+## Production Build
+
+To generate an optimized build for deployment run:
+
+```bash
+npm run build
+```
+
+The compiled assets will be placed in the `dist/` directory.
+

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://nzhyjnsxgrkckjxwesbk.supabase.co';
-const supabaseKey =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im56aHlqbnN4Z3JrY2tqeHdlc2JrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAyNjgzOTQsImV4cCI6MjA2NTg0NDM5NH0.ZZ5fIgYXhcPyGt3mhI_sx7j8bnOkS7HxuIKfyXeoI70';
+// Values are loaded from Vite environment variables. See README for setup.
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- provide project overview and steps to run the app in new README
- add example env file for Supabase credentials
- load Supabase credentials from Vite env variables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c1fd8c3748333abf4c161f6cede91